### PR TITLE
Read the device serial number correctly

### DIFF
--- a/custom_components/sungrow/registers-sungrow.yaml
+++ b/custom_components/sungrow/registers-sungrow.yaml
@@ -25,7 +25,7 @@ registers:
     - name: "serial_number"
       level: 2
       address: 4990
-      datatype: "UTF-8"
+      datatype: "UTF-8[10]"
     - name: "device_type_code"
       level: 2
       address: 5000

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 import voluptuous as vol
+import dataclasses
 
 from homeassistant.components.sensor import (
     SensorEntity
@@ -146,7 +147,11 @@ async def async_setup_entry(
 
     # Register our sensor entities
     entities = []
-    for description in SENSOR_TYPES:
+    for DESCRIPTION in SENSOR_TYPES:
+        # Create a copy, so we don't modify SENSOR_TYPES in place.
+        # We cannot have different Sensors use the same SensorEntityDescription.
+        description = dataclasses.replace(DESCRIPTION)
+
         # Add in the owning device's unique id
         description.device_id = unique_device_id
         description.device_model = coordinator.data.getInverterModel()
@@ -181,7 +186,7 @@ class SungrowInverterSensorEntity(CoordinatorEntity, SensorEntity):
             return None
         return DeviceInfo(
             identifiers={(DOMAIN, self.entity_description.device_id)},
-            name=f'Sungrow {self.entity_description.device_model}',
+            name=f'Sungrow {self.entity_description.device_model} {self.entity_description.device_id}',
             manufacturer='Sungrow',
             model=self.entity_description.device_model,
         )


### PR DESCRIPTION
As discovered in #1 the serial number is 10 registers and not a single one.
Here is one idea how to implement it.

While this doesn't address all the problems with multiple inverters, it should be enough to close #1:
![image](https://github.com/alangibson/homeassistant-sungrow/assets/5074553/5022311f-0129-4fba-b9d0-9772f8a8067b)


As I don't have the slightest idea how to implement tests here, this code is "works for me".

Note: this will change entity ids and therefore all previously collected data is lost.


This is what it looks like after this PR:
![image](https://github.com/alangibson/homeassistant-sungrow/assets/5074553/f3c28766-45dc-4a0a-bb88-a06067f14196)
